### PR TITLE
bump of version for magento framework dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Created by .ignore support plugin (hsz.mobi)
+.idea

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
     "name": "msp/cmsimportexport",
     "description": "",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0",
-        "magento/framework": "100.0.*",
+        "php": "~5.6.5|7.0.2|7.0.4|~7.0.6",
+        "magento/framework": "100.*",
         "msp/common": "*",
         "magento/magento-composer-installer": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "",
     "require": {
         "php": "~5.6.5|7.0.2|7.0.4|~7.0.6",
-        "magento/framework": "100.*",
+        "magento/framework": "100.1.*",
         "msp/common": "*",
         "magento/magento-composer-installer": "*"
     },

--- a/view/adminhtml/ui_component/cms_block_listing.xml
+++ b/view/adminhtml/ui_component/cms_block_listing.xml
@@ -20,7 +20,7 @@
  */
 -->
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
-    <container name="listing_top">
+    <listingToolbar name="listing_top">
         <massaction name="listing_massaction">
             <action name="export">
                 <argument name="data" xsi:type="array">
@@ -32,5 +32,5 @@
                 </argument>
             </action>
         </massaction>
-    </container>
+    </listingToolbar>
 </listing>

--- a/view/adminhtml/ui_component/cms_page_listing.xml
+++ b/view/adminhtml/ui_component/cms_page_listing.xml
@@ -20,7 +20,7 @@
  */
 -->
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
-    <container name="listing_top">
+    <listingToolbar name="listing_top">
         <massaction name="listing_massaction">
             <action name="export">
                 <argument name="data" xsi:type="array">
@@ -32,5 +32,5 @@
                 </argument>
             </action>
         </massaction>
-    </container>
+    </listingToolbar>
 </listing>


### PR DESCRIPTION
added gitignore 
bump of version for magento framework dependency
correct php required version with magento 2.1.7