### PR TITLE
Use `array_merge()` to merge media arrays, not `+=`

### DIFF
--- a/Model/Content.php
+++ b/Model/Content.php
@@ -260,7 +260,7 @@ class Content implements ContentInterface
         foreach ($blockInterfaces as $blockInterface) {
             $blockInfo = $this->blockToArray($blockInterface);
             $blocks[$this->_getBlockKey($blockInterface)] = $blockInfo;
-            $media += $blockInfo['media'];
+            $media = array_merge($media, $blockInfo['media']);
         }
 
         return [
@@ -282,7 +282,7 @@ class Content implements ContentInterface
         foreach ($pageInterfaces as $pageInterface) {
             $pageInfo = $this->pageToArray($pageInterface);
             $pages[$this->_getPageKey($pageInterface)] = $pageInfo;
-            $media += $pageInfo['media'];
+            $media = array_merge($media, $pageInfo['media']);
         }
 
         return [


### PR DESCRIPTION
Hi there! First, thanks for the extension, it's been quite useful to us.

This PR changes the media collection for exporting multiple pages/blocks to use `array_merge()` instead of array union `+=`. Not all media gets exported when exporting en masse because array keys already exist after the first page has been exported.